### PR TITLE
Fix Gestion __str__ method

### DIFF
--- a/academico/models.py
+++ b/academico/models.py
@@ -28,7 +28,7 @@ class Gestion(models.Model):
         ordering = ['anio', 'trimestre']
 
     def __str__(self):
-        return f'{self.anio} - {self.semestre}'
+        return f'{self.anio} - {self.trimestre}'
 
 
 class Curso(models.Model):


### PR DESCRIPTION
## Summary
- fix typo in Gestion `__str__` method referencing non-existent field

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6843be0d0a608327ba67b999bf7d5d3e