### PR TITLE
Add Swagger decorators for API views

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ python manage.py runserver
 
 Luego visita [http://localhost:8000](http://localhost:8000) en tu navegador para ver la aplicación en acción.
 
+La documentación interactiva de la API estará disponible en [http://localhost:8000/swagger/](http://localhost:8000/swagger/).
+
 ---
 
 ## Población de datos (Opcional)

--- a/academico/views.py
+++ b/academico/views.py
@@ -2,6 +2,8 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
 from rest_framework import viewsets
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 from usuarios.permissions import has_role
 from .models import AsignacionProfesorMateria, Clase, Inscripcion, Curso, Gestion, Materia, NotaMateria
 from .serializers import ClaseSerializer, InscripcionSerializer, CursoSerializer, GestionSerializer, AsignacionProfesorMateriaSerializer, MateriaSerializer, NotaMateriaSerializer
@@ -12,29 +14,40 @@ from asistencia.serializers import HorarioSerializer
 from evaluaciones.models import Tarea, Examen, EntregaTarea, ResultadoExamen
 
 class CursoViewSet(viewsets.ModelViewSet):
+    """CRUD de cursos del colegio."""
     queryset = Curso.objects.all()
     serializer_class = CursoSerializer
 
 class GestionViewSet(viewsets.ModelViewSet):
+    """Gestiona las gestiones académicas."""
     queryset = Gestion.objects.all()
     serializer_class = GestionSerializer
 
 class ClaseViewSet(viewsets.ModelViewSet):
+    """CRUD de clases."""
     queryset = Clase.objects.all()
     serializer_class = ClaseSerializer
 
 class MateriaViewSet(viewsets.ModelViewSet):
+    """Operaciones sobre materias."""
     queryset = Materia.objects.all()
     serializer_class = MateriaSerializer
 
 class AsignacionProfesorMateriaViewSet(viewsets.ModelViewSet):
+    """Relaciona profesores con materias."""
     queryset = AsignacionProfesorMateria.objects.all()
     serializer_class = AsignacionProfesorMateriaSerializer
 
+@swagger_auto_schema(
+    method='get',
+    responses={200: InscripcionSerializer(many=True)},
+    operation_summary="Listar mis alumnos"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @has_role('profesor')
 def get_my_alumnos(request):
+    """Lista los alumnos de las clases del profesor autenticado."""
     usuario = request.user
     profesor = usuario.profesor
 
@@ -58,10 +71,16 @@ def get_my_alumnos(request):
     return Response(serializer.data)
 
 
+@swagger_auto_schema(
+    method='get',
+    responses={200: AlumnoSerializer(many=True)},
+    operation_summary="Alumnos por horario"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @has_role('profesor')
 def get_alumnos_by_horario(request, horario_id):
+    """Obtiene alumnos según un horario específico."""
     usuario = request.user
 
     profesor = usuario.profesor
@@ -83,10 +102,16 @@ def get_alumnos_by_horario(request, horario_id):
     return Response(serializer.data)
 
 
+@swagger_auto_schema(
+    method='get',
+    responses={200: ClaseSerializer()},
+    operation_summary="Clase por horario"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @has_role('profesor')
 def get_clases_by_horario(request, horario_id):
+    """Devuelve la clase asociada a un horario."""
     usuario = request.user
 
     profesor = usuario.profesor
@@ -104,6 +129,11 @@ def get_clases_by_horario(request, horario_id):
     return Response(serializer.data)
 
 
+@swagger_auto_schema(
+    method='get',
+    responses={200: openapi.Response('Listado de notas')},
+    operation_summary="Notas por alumno"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated, IsAdminUser])
 def get_notas_by_alumno(request, alumno_id):
@@ -128,6 +158,12 @@ def get_notas_by_alumno(request, alumno_id):
     return Response(notas)
 
 
+@swagger_auto_schema(
+    method='put',
+    request_body=InscripcionSerializer,
+    responses={200: InscripcionSerializer},
+    operation_summary="Registrar notas"
+)
 @api_view(['PUT'])
 @permission_classes([IsAuthenticated])
 @has_role('profesor')
@@ -159,6 +195,11 @@ def registrar_notas(request, inscripcion_id):
     return Response(InscripcionSerializer(inscripcion).data)
 
 
+@swagger_auto_schema(
+    method='get',
+    responses={200: InscripcionSerializer(many=True)},
+    operation_summary="Mis notas"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @has_role('alumno')
@@ -173,9 +214,15 @@ def mis_notas(request):
     return Response(serializer.data)
 
 
+@swagger_auto_schema(
+    method='get',
+    responses={200: ClaseSerializer(many=True)},
+    operation_summary="Mis clases"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def mis_clases(request):
+    """Devuelve las clases asignadas al profesor autenticado."""
     # 1. Obtener la gestión actual
     gestion_actual = Gestion.objects.latest('anio', 'trimestre')
     
@@ -198,6 +245,12 @@ def mis_clases(request):
     return Response(serializer.data)
 
 
+@swagger_auto_schema(
+    method='post',
+    request_body=HorarioSerializer,
+    responses={201: HorarioSerializer},
+    operation_summary="Asignar profesor_materia a clase"
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def asignar_profesor_materia_a_clase(request):
@@ -223,6 +276,12 @@ def asignar_profesor_materia_a_clase(request):
     return Response(serializer.data, status=201 if created else 200)
 
 
+@swagger_auto_schema(
+    method='post',
+    request_body=AsignacionProfesorMateriaSerializer,
+    responses={201: AsignacionProfesorMateriaSerializer},
+    operation_summary="Asignar materia a profesor"
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def asignar_materia_a_profesor(request):
@@ -244,6 +303,12 @@ def asignar_materia_a_profesor(request):
     return Response(serializer.data, status=201 if created else 200)
 
 
+@swagger_auto_schema(
+    method='post',
+    request_body=InscripcionSerializer,
+    responses={201: InscripcionSerializer},
+    operation_summary="Inscribir alumno a clase"
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def inscribir_alumno_a_clase(request):
@@ -265,10 +330,20 @@ def inscribir_alumno_a_clase(request):
     return Response(serializer.data, status=201 if created else 200)
 
 
+@swagger_auto_schema(
+    method='get',
+    manual_parameters=[
+        openapi.Parameter('materia_id', openapi.IN_QUERY, description='ID de la materia', type=openapi.TYPE_INTEGER, required=True),
+        openapi.Parameter('gestion_id', openapi.IN_QUERY, description='ID de la gestión (opcional)', type=openapi.TYPE_INTEGER, required=False),
+    ],
+    responses={200: openapi.Response('Alumnos de materia')},
+    operation_summary="Desempeño de alumnos por materia"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @has_role('profesor')
 def alumnos_de_materia(request):
+    """Muestra el desempeño de los alumnos en una materia."""
     profesor = request.user.profesor
     materia_id = request.GET.get('materia_id')
     gestion_id = request.GET.get('gestion_id')
@@ -350,9 +425,19 @@ def alumnos_de_materia(request):
     return Response(resultado)
 
 
+@swagger_auto_schema(
+    method='get',
+    manual_parameters=[
+        openapi.Parameter('materia_id', openapi.IN_QUERY, description='ID de la materia', type=openapi.TYPE_INTEGER, required=True),
+        openapi.Parameter('gestion_id', openapi.IN_QUERY, description='ID de la gestión (opcional)', type=openapi.TYPE_INTEGER, required=False),
+    ],
+    responses={200: NotaMateriaSerializer(many=True)},
+    operation_summary="Mis notas de una materia"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def mis_notas_materia(request):
+    """Notas del alumno en una materia y gestión determinada."""
     alumno = request.user.alumno  # Asume que el usuario es un alumno
     materia_id = request.GET.get('materia_id')
     gestion_id = request.GET.get('gestion_id')
@@ -384,9 +469,18 @@ def mis_notas_materia(request):
     return Response(serializer.data)
 
 
+@swagger_auto_schema(
+    method='get',
+    manual_parameters=[
+        openapi.Parameter('gestion_id', openapi.IN_QUERY, description='ID de la gestión (opcional)', type=openapi.TYPE_INTEGER, required=False)
+    ],
+    responses={200: openapi.Response('Libreta completa')},
+    operation_summary="Mi libreta"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def mi_libreta(request):
+    """Libreta de calificaciones completa del alumno autenticado."""
     alumno = request.user.alumno  # Asume que el usuario es un alumno
     gestion_id = request.GET.get('gestion_id')
 

--- a/asistencia/views.py
+++ b/asistencia/views.py
@@ -4,8 +4,22 @@ from rest_framework.response import Response
 from django.utils import timezone
 from usuarios.permissions import has_role
 from .models import Horario, Asistencia
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
+@swagger_auto_schema(
+    method='post',
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={
+            'fecha': openapi.Schema(type=openapi.TYPE_STRING, format='date'),
+            'asistencias': openapi.Schema(type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_OBJECT)),
+        },
+    ),
+    responses={200: openapi.Response('Asistencia registrada')},
+    operation_summary="Registrar asistencia"
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 @has_role('profesor')

--- a/colegio_backend/settings.py
+++ b/colegio_backend/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'drf_yasg',
     'corsheaders',
     'usuarios',
     'academico',

--- a/colegio_backend/urls.py
+++ b/colegio_backend/urls.py
@@ -15,9 +15,21 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from usuarios.views import RegisterView, LoginView
-from django.urls import include
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+from rest_framework import permissions
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="API Colegio",
+        default_version='v1',
+        description="Documentación de la API del sistema de gestión escolar",
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -27,5 +39,7 @@ urlpatterns = [
     path('academico/', include('academico.urls')),
     path('asistencia/', include('asistencia.urls')),
     path('evaluaciones/', include('evaluaciones.urls')),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]
 

--- a/evaluaciones/views.py
+++ b/evaluaciones/views.py
@@ -4,8 +4,19 @@ from rest_framework.response import Response
 from usuarios.permissions import has_role
 from .models import Participacion
 from asistencia.models import Asistencia
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 
+@swagger_auto_schema(
+    method='post',
+    request_body=openapi.Schema(
+        type=openapi.TYPE_OBJECT,
+        properties={'observacion': openapi.Schema(type=openapi.TYPE_STRING)},
+    ),
+    responses={200: openapi.Response('Participación registrada')},
+    operation_summary="Registrar participación"
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 @has_role('profesor')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ djangorestframework_simplejwt==5.5.0
 PyJWT==2.9.0
 sqlparse==0.5.3
 tzdata==2025.2
+drf-yasg==1.21.7

--- a/usuarios/views.py
+++ b/usuarios/views.py
@@ -7,27 +7,40 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from django.db.transaction import atomic as transaction_atomic
 from rest_framework import viewsets
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 class UsuarioViewSet(viewsets.ModelViewSet):
+    """API CRUD para usuarios generales."""
     queryset = Alumno.objects.all()
     serializer_class = UsuarioSerializer
 
 class ProfesorViewSet(viewsets.ModelViewSet):
+    """Gestiona las operaciones de profesores."""
     queryset = Profesor.objects.all()
     serializer_class = ProfesorSerializer
 
 class AlumnoViewSet(viewsets.ModelViewSet):
+    """Gestiona las operaciones de alumnos."""
     queryset = Alumno.objects.all()
     serializer_class = AlumnoSerializer
 
 
 def get_tokens_for_user(user):
+    """Genera un token JWT de acceso para el usuario dado."""
     refresh = RefreshToken.for_user(user)
     return str(refresh.access_token)
 
 
+@swagger_auto_schema(
+    method='post',
+    request_body=RegisterSerializer,
+    responses={201: UsuarioSerializer},
+    operation_summary="Registrar usuario"
+)
 @api_view(['POST'])
 def RegisterView(request):
+    """Registra un usuario genérico y devuelve su token de acceso."""
     serializer = RegisterSerializer(data=request.data)
     if serializer.is_valid():
         user = serializer.save()
@@ -42,8 +55,15 @@ def RegisterView(request):
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@swagger_auto_schema(
+    method='post',
+    request_body=LoginSerializer,
+    responses={200: UsuarioSerializer},
+    operation_summary="Iniciar sesión"
+)
 @api_view(['POST'])
 def LoginView(request):
+    """Autentica un usuario y retorna su token JWT."""
     serializer = LoginSerializer(data=request.data)
     if serializer.is_valid():
         user = serializer.validated_data['user']
@@ -56,10 +76,17 @@ def LoginView(request):
     return Response(serializer.errors, status=status.HTTP_401_UNAUTHORIZED)
 
 
+@swagger_auto_schema(
+    method='post',
+    request_body=RegisterSerializer,
+    responses={201: UsuarioSerializer},
+    operation_summary="Registrar profesor"
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated, IsAdminUser])
 @transaction_atomic
 def RegisterProfesorView(request):
+    """Crea un nuevo profesor dentro del sistema."""
     serializer = RegisterSerializer(data=request.data)
     if serializer.is_valid():
         user = serializer.save()
@@ -73,10 +100,17 @@ def RegisterProfesorView(request):
             status=status.HTTP_201_CREATED)
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+@swagger_auto_schema(
+    method='post',
+    request_body=RegisterSerializer,
+    responses={201: UsuarioSerializer},
+    operation_summary="Registrar alumno"
+)
 @api_view(['POST'])
 @permission_classes([IsAuthenticated, IsAdminUser])
 @transaction_atomic
 def RegisterAlumnoView(request):
+    """Registra un alumno asociado a un usuario existente."""
     serializer = RegisterSerializer(data=request.data)
     if serializer.is_valid():
         user = serializer.save()
@@ -89,6 +123,11 @@ def RegisterAlumnoView(request):
 
 
 
+@swagger_auto_schema(
+    method='get',
+    responses={200: AlumnoSerializer(many=True)},
+    operation_summary="Listar alumnos"
+)
 @api_view(['GET'])
 @permission_classes([IsAuthenticated, IsAdminUser])
 def get_alumnos(request):


### PR DESCRIPTION
## Summary
- add swagger_auto_schema usage in academico app views
- document asistencia, evaluaciones and usuarios views with Swagger decorators

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684620ab2dc88327aceb205dfe638c9f